### PR TITLE
#9: wait for the database layer

### DIFF
--- a/.gitpod/bootstrap.sh
+++ b/.gitpod/bootstrap.sh
@@ -34,6 +34,8 @@ elif [ -n "$repo" ]; then
   repostring="--repo=$repo"
 fi;
 
+sleep 20
+
 joomla site:download ${APACHE_DOCROOT_IN_REPO} --www=$GITPOD_REPO_ROOT $release $repostring
 
 joomla site:configure ${APACHE_DOCROOT_IN_REPO} --www=$GITPOD_REPO_ROOT --overwrite --mysql-login=root:

--- a/.gitpod/bootstrap.sh
+++ b/.gitpod/bootstrap.sh
@@ -34,8 +34,6 @@ elif [ -n "$repo" ]; then
   repostring="--repo=$repo"
 fi;
 
-sleep 20
-
 joomla site:download ${APACHE_DOCROOT_IN_REPO} --www=$GITPOD_REPO_ROOT $release $repostring
 
 joomla site:configure ${APACHE_DOCROOT_IN_REPO} --www=$GITPOD_REPO_ROOT --overwrite --mysql-login=root:
@@ -43,6 +41,11 @@ joomla site:configure ${APACHE_DOCROOT_IN_REPO} --www=$GITPOD_REPO_ROOT --overwr
 if [ -e "$GITPOD_REPO_ROOT/.gitpod/install.sql" ]; then
   custom_install="--sql-dumps=$GITPOD_REPO_ROOT/.gitpod/install.sql";
 fi;
+
+#wait for the database to ready
+while ! mysqladmin ping -h"$DB_HOST" --silent; do
+    sleep 1
+done
 
 joomla database:install  ${APACHE_DOCROOT_IN_REPO} --www=$GITPOD_REPO_ROOT --drop --mysql-login=root: $custom_install
 

--- a/.gitpod/bootstrap.sh
+++ b/.gitpod/bootstrap.sh
@@ -43,7 +43,7 @@ if [ -e "$GITPOD_REPO_ROOT/.gitpod/install.sql" ]; then
 fi;
 
 #wait for the database to ready
-while ! mysqladmin ping -h"$DB_HOST" --silent; do
+while ! mysqladmin ping --silent; do
     sleep 1
 done
 


### PR DESCRIPTION
This PR closes #9 

<img width="1211" alt="Screenshot 2021-05-20 at 14 03 27" src="https://user-images.githubusercontent.com/3769817/118983331-361ac100-b974-11eb-92e2-88c3829dab7d.png">

```
* About to set up the gitpod area
Warning from https://repo.packagist.org: You are using an outdated version of Composer. Composer 2 is now available and you should upgrade. See https://getcomposer.org/2
./composer.json has been created
Loading composer repositories with package information
Warning from https://repo.packagist.org: You are using an outdated version of Composer. Composer 2 is now available and you should upgrade. See https://getcomposer.org/2
Updating dependencies (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Installing joomlatools/console-joomlatools (dev-master 9bbedf7): Cloning 9bbedf7143 from cache
Writing lock file
Generating autoload files
* Create a new Joomla site
Downloading https://github.com/joomla/joomla-cms/archive/3.9.26.tar.gz - this could take a few minutes ..
mysqld is alive
```
